### PR TITLE
Allow to deffer subroutine/constant calling

### DIFF
--- a/lib/FFI/Platypus/Type/Enum.pm
+++ b/lib/FFI/Platypus/Type/Enum.pm
@@ -202,6 +202,9 @@ sub ffi_custom_type_api_1
   foreach my $value (@values)
   {
     my $name;
+    if( ref $value eq 'CODE' ) {
+      $value =  $value->();
+    }
     if(is_plain_arrayref $value)
     {
       ($name,$index) = @$value;

--- a/t/ffi_platypus_type_enum.t
+++ b/t/ffi_platypus_type_enum.t
@@ -168,11 +168,6 @@ subtest 'define errors' => sub {
   );
 
   is(
-    dies { $ffi->load_custom_type('::Enum','enum1', sub {}) },
-    match qr/not a array ref or scalar: CODE/,
-  );
-
-  is(
     dies { $ffi->load_custom_type('::Enum','enum1', 'one','one') },
     match qr/one declared twice/,
   );


### PR DESCRIPTION
I am doing perl binding for SDL2 https://www.libsdl.org/download-2.0.php

in `include/SDL_pixels.h` there is next enum:

```
typedef enum
{
    SDL_PIXELFORMAT_UNKNOWN,
    ...
    SDL_PIXELFORMAT_RGBA8888 =
        SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBA,
                               SDL_PACKEDLAYOUT_8888, 32, 4),
   ...
    /* Aliases for RGBA byte arrays of color data, for the current platform */
#if SDL_BYTEORDER == SDL_BIG_ENDIAN
    SDL_PIXELFORMAT_RGBA32 = SDL_PIXELFORMAT_RGBA8888,
    SDL_PIXELFORMAT_ARGB32 = SDL_PIXELFORMAT_ARGB8888,
    SDL_PIXELFORMAT_BGRA32 = SDL_PIXELFORMAT_BGRA8888,
    SDL_PIXELFORMAT_ABGR32 = SDL_PIXELFORMAT_ABGR8888,
#else
    SDL_PIXELFORMAT_RGBA32 = SDL_PIXELFORMAT_ABGR8888,
    SDL_PIXELFORMAT_ARGB32 = SDL_PIXELFORMAT_BGRA8888,
    SDL_PIXELFORMAT_BGRA32 = SDL_PIXELFORMAT_ARGB8888,
    SDL_PIXELFORMAT_ABGR32 = SDL_PIXELFORMAT_RGBA8888,
#endif
    ....
} SDL_PixelFormatEnum;
```
I convert it like next:
```
# required forward declaration
sub SDL_PIXELFORMAT_RGBA8888();

$ffi->load_custom_type('::Enum', 'SDL_PixelFormatEnum',
	{ ret => 'int', package => 'SDL2::Pixels' },
	'SDL_PIXELFORMAT_UNKNOWN',
        ....
    [ SDL_PIXELFORMAT_RGBA8888 => SDL_DEFINE_PIXELFORMAT(
		SDL2::Pixels::SDL_PIXELTYPE_PACKED32, SDL2::Pixels::SDL_PACKEDORDER_RGBA,
		SDL2::Pixels::SDL_PACKEDLAYOUT_8888, 32, 4
	)],
	SDL2::Endian::SDL_BYTEORDER == SDL2::Endian::SDL_BIG_ENDIAN? (
	    [SDL_PIXELFORMAT_RGBA32 => SDL_PIXELFORMAT_RGBA8888],
	    [SDL_PIXELFORMAT_ARGB32 => SDL_PIXELFORMAT_ARGB8888],
	    [SDL_PIXELFORMAT_BGRA32 => SDL_PIXELFORMAT_BGRA8888],
	    [SDL_PIXELFORMAT_ABGR32 => SDL_PIXELFORMAT_ABGR8888],
	) : (
	    [SDL_PIXELFORMAT_RGBA32 => SDL_PIXELFORMAT_ABGR8888],
	    [SDL_PIXELFORMAT_ARGB32 => SDL_PIXELFORMAT_BGRA8888],
	    [SDL_PIXELFORMAT_BGRA32 => SDL_PIXELFORMAT_ARGB8888],
	    [SDL_PIXELFORMAT_ABGR32 => SDL_PIXELFORMAT_RGBA8888],
	)
);                           
```
because of `?:` works first before `load_custom_type` is called. I get error:

    Undefined subroutine &SDL2::Pixels::SDL_PIXELFORMAT_ABGR8888 called at ...

This patch allow to defer call to `SDL_PIXELFORMAT_ABGR8888`. Now declaration looks like:
```
	SDL2::Endian::SDL_BYTEORDER == SDL2::Endian::SDL_BIG_ENDIAN? (
	    sub{ [SDL_PIXELFORMAT_RGBA32 => SDL_PIXELFORMAT_RGBA8888] },
	    sub{ [SDL_PIXELFORMAT_ARGB32 => SDL_PIXELFORMAT_ARGB8888] },
	    sub{ [SDL_PIXELFORMAT_BGRA32 => SDL_PIXELFORMAT_BGRA8888] },
	    sub{ [SDL_PIXELFORMAT_ABGR32 => SDL_PIXELFORMAT_ABGR8888] },
	) : (
	    sub{ [SDL_PIXELFORMAT_RGBA32 => SDL_PIXELFORMAT_ABGR8888] },
	    sub{ [SDL_PIXELFORMAT_ARGB32 => SDL_PIXELFORMAT_BGRA8888] },
	    sub{ [SDL_PIXELFORMAT_BGRA32 => SDL_PIXELFORMAT_ARGB8888] },
	    sub{ [SDL_PIXELFORMAT_ABGR32 => SDL_PIXELFORMAT_RGBA8888] },
	)
```

and works without problem