### PR TITLE
value aliasing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}},
 
 {{$NEXT}}
+  - Add value aliases (gh#6)
 
 0.03      2020-05-12 09:26:39 -0600
   - Fixed unclear documentation. (gh#3)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Perl with constants:
 use FFI::Platypus 1.00;
 my $ffi = FFI::Platypus->new( api => 1 );
 
-$ffi->load_custom_type('::Enum', 'foo_t', 
+$ffi->load_custom_type('::Enum', 'foo_t',
   { ret => 'int', package => 'Foo', prefix => 'FOO_' },
   'default',
   'better',
@@ -96,89 +96,143 @@ $ffi->load_custom_type('::Enum', $name, @values);
 ```
 
 The enumerated values are specified as a list of strings and array references.
-For strings the constant value starts at zero (0) and increases by one for each
-possible value.  You can use an array reference to indicate an alternate integer
-value to go with your constant.
 
-Options may be passed in as a hash reference after the type name.
+- string
 
-## maps
+    ```
+    $ffi->load_custom_type('::Enum', $name, $string1, $string2, ... );
+    ```
 
-```perl
-my @maps;
-$ffi->load_custom_type('::Enum', $name, { maps => \@maps }, ... );
-my($str,$int,$type) = @maps;
-```
+    For strings the constant value starts at zero (0) and increases by one for each
+    possible value.
 
-If set to an empty array reference, this will be filled with the string, integer
-and native type for the enum.
+- array reference
 
-## package
+    ```
+    $ffi->load_custom_type('::Enum', $name, [ $value_name, $value, %options ]);
+    $ffi->load_custom_type('::Enum', $name, [ $value_name, %options ]);
+    ```
 
-```perl
-$ffi->load_custom_type('::Enum', $name, { package => $package }, ... );
-```
+    You can use an array reference to include an explicit integer value, rather
+    than using the implicit incremented value.  You can also use the array
+    reference for value options.  If the value isn't included (that is if
+    there are an odd number of values in the array reference), then the
+    implicit incremented value will be used.
 
-This option specifies the Perl package where constants will be defined.
-If not specified, then not constants will be generated.  As per the usual
-convention, the constants will be the upper case of the value names.
+    Value options:
 
-## prefix
+    - alias
 
-```perl
-$ffi->load_custom_type('::Enum', $name, { prefix => $prefix }, ... );
-```
+        ```perl
+        $ffi->load_custom_type('::Enum, $name, [ $value_name, $value, alias => \@aliases ]);
+        $ffi->load_custom_type('::Enum, $name, [ $value_name, alias => \@aliases ]);
+        ```
 
-This specifies an optional prefix to give each constant.  If not specified,
-then no prefix will be used.
+        The `alias` option lets you specify value aliases.  For example, suppose you have
+        an enum definition like:
 
-## rev
+        ```
+        enum {
+          FOO,
+          BAR,
+          BAZ=BAR,
+          ABC,
+          XYZ
+        } foo_t;
+        ```
 
-```perl
-$ffi->load_custom_type('::Enum', $name, { prefix => 'int' }, ... );
-$ffi->load_custom_type('::Enum', $name, { prefix => 'str' }, ... );
-```
+        The Perl definition would be:
 
-This specifies what should be returned for C functions that return the
-enumerated type.  For strings, use `str`, and for integer constants
-use `int`.
+        ```perl
+        $ffi->load_custom_type('::Enum', 'foo_t',
+          'foo',
+          ['bar', alias => ['baz']],
+          'abc',
+          'xyz',
+        );
+        ```
 
-## type
+Type options may be passed in as a hash reference after the type name.
 
-```perl
-$ffi->load_custom_type('::Enum', $name, { type => $type }, ... );
-```
+Type options:
 
-This specifies the integer type that should be used for the enumerated
-type.  The default is to use `enum` for types that only have positive
-possible values and `senum` for types that have possible negative values.
-(Note that on some platforms these two types may actually be the same).
+- maps
 
-You can also use other integer types, which is useful if the enum is
-only used to define constants, and the values are stored in a type
-smaller than the default for `enum` or `senum`.  For example:
+    ```perl
+    my @maps;
+    $ffi->load_custom_type('::Enum', $name, { maps => \@maps }, ... );
+    my($str,$int,$type) = @maps;
+    ```
 
-C:
+    If set to an empty array reference, this will be filled with the string, integer
+    and native type for the enum.
 
-```
-enum {
-  DEFAULT,
-  BETTER,
-  BEST = 12
-} foo_enum;
-typedef uint8_t foo_t;
-```
+- package
 
-Perl:
+    ```perl
+    $ffi->load_custom_type('::Enum', $name, { package => $package }, ... );
+    ```
 
-```perl
-$ffi->load_custom_type('::Enum', 'foo_t',
-  { type => 'uint8' },
-  'default',
-  'better',
-  [best => 12],
-);
-```
+    This option specifies the Perl package where constants will be defined.
+    If not specified, then not constants will be generated.  As per the usual
+    convention, the constants will be the upper case of the value names.
+
+- prefix
+
+    ```perl
+    $ffi->load_custom_type('::Enum', $name, { prefix => $prefix }, ... );
+    ```
+
+    This specifies an optional prefix to give each constant.  If not specified,
+    then no prefix will be used.
+
+- rev
+
+    ```perl
+    $ffi->load_custom_type('::Enum', $name, { prefix => 'int' }, ... );
+    $ffi->load_custom_type('::Enum', $name, { prefix => 'str' }, ... );
+    ```
+
+    This specifies what should be returned for C functions that return the
+    enumerated type.  For strings, use `str`, and for integer constants
+    use `int`.
+
+- type
+
+    ```perl
+    $ffi->load_custom_type('::Enum', $name, { type => $type }, ... );
+    ```
+
+    This specifies the integer type that should be used for the enumerated
+    type.  The default is to use `enum` for types that only have positive
+    possible values and `senum` for types that have possible negative values.
+    (Note that on some platforms these two types may actually be the same).
+
+    You can also use other integer types, which is useful if the enum is
+    only used to define constants, and the values are stored in a type
+    smaller than the default for `enum` or `senum`.  For example:
+
+    C:
+
+    ```
+    enum {
+      DEFAULT,
+      BETTER,
+      BEST = 12
+    } foo_enum;
+    typedef uint8_t foo_t;
+    ```
+
+    Perl:
+
+    ```perl
+    $ffi->load_custom_type('::Enum', 'foo_t',
+      { type => 'uint8' },
+      'default',
+      'better',
+      [best => 12],
+    );
+    ```
 
 # SEE ALSO
 

--- a/lib/FFI/Platypus/Type/Enum.pm
+++ b/lib/FFI/Platypus/Type/Enum.pm
@@ -207,9 +207,14 @@ sub ffi_custom_type_api_1
     if(is_plain_arrayref $value)
     {
       my %opt;
-      my $v;
-      ($name,$v,%opt) = @$value;
-      $index = $v if defined $v;
+      if(@$value % 2)
+      {
+        ($name,%opt) = @$value;
+      }
+      else
+      {
+        ($name,$index,%opt) = @$value;
+      }
       @aliases = @{ delete $opt{alias} || [] };
       croak("unrecognized options: @{[ sort keys %opt ]}") if %opt;
     }

--- a/lib/FFI/Platypus/Type/Enum.pm
+++ b/lib/FFI/Platypus/Type/Enum.pm
@@ -19,7 +19,7 @@ C:
    BETTER,
    BEST = 12
  } foo_t;
-
+ 
  foo_t
  f(foo_t arg)
  {
@@ -30,18 +30,18 @@ Perl with strings:
 
  use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
-
+ 
  $ffi->load_custom_type('::Enum', 'foo_t',
    'default',
    'better',
    ['best' => 12],
  );
-
+ 
  $ffi->attach( f => ['foo_t'] => 'foo_t' );
-
+ 
  f("default") eq 'default';  # true
  f("default") eq 'better';   # false
-
+ 
  print f("default"), "\n";   # default
  print f("better"),  "\n";   # better
  print f("best"),    "\n";   # best
@@ -50,19 +50,19 @@ Perl with constants:
 
  use FFI::Platypus 1.00;
  my $ffi = FFI::Platypus->new( api => 1 );
-
- $ffi->load_custom_type('::Enum', 'foo_t', 
+ 
+ $ffi->load_custom_type('::Enum', 'foo_t',
    { ret => 'int', package => 'Foo', prefix => 'FOO_' },
    'default',
    'better',
    ['best' => 12],
  );
-
+ 
  $ffi->attach( f => ['foo_t'] => 'foo_t' );
-
+ 
  f(Foo::FOO_DEFAULT) == Foo::FOO_DEFAULT;   # true
  f(Foo::FOO_DEFAULT) == Foo::FOO_BETTER;    # false
- 
+
 
 =head1 DESCRIPTION
 
@@ -101,13 +101,67 @@ The general form of the custom type load is:
  $ffi->load_custom_type('::Enum', $name, @values);
 
 The enumerated values are specified as a list of strings and array references.
+
+=over 4
+
+=item string
+
+ $ffi->load_custom_type('::Enum', $name, $string1, $string2, ... );
+
 For strings the constant value starts at zero (0) and increases by one for each
-possible value.  You can use an array reference to indicate an alternate integer
-value to go with your constant.
+possible value.
 
-Options may be passed in as a hash reference after the type name.
+=item array reference
 
-=head2 maps
+ $ffi->load_custom_type('::Enum', $name, [ $value_name, $value, %options ]);
+ $ffi->load_custom_type('::Enum', $name, [ $value_name, %options ]);
+
+You can use an array reference to include an explicit integer value, rather
+than using the implicit incremented value.  You can also use the array
+reference for value options.  If the value isn't included (that is if
+there are an odd number of values in the array reference), then the
+implicit incremented value will be used.
+
+Value options:
+
+=over 4
+
+=item alias
+
+ $ffi->load_custom_type('::Enum, $name, [ $value_name, $value, alias => \@aliases ]);
+ $ffi->load_custom_type('::Enum, $name, [ $value_name, alias => \@aliases ]);
+
+The C<alias> option lets you specify value aliases.  For example, suppose you have
+an enum definition like:
+
+ enum {
+   FOO,
+   BAR,
+   BAZ=BAR,
+   ABC,
+   XYZ
+ } foo_t;
+
+The Perl definition would be:
+
+ $ffi->load_custom_type('::Enum', 'foo_t',
+   'foo',
+   ['bar', alias => ['baz']],
+   'abc',
+   'xyz',
+ );
+
+=back
+
+=back
+
+Type options may be passed in as a hash reference after the type name.
+
+Type options:
+
+=over 4
+
+=item maps
 
  my @maps;
  $ffi->load_custom_type('::Enum', $name, { maps => \@maps }, ... );
@@ -116,7 +170,7 @@ Options may be passed in as a hash reference after the type name.
 If set to an empty array reference, this will be filled with the string, integer
 and native type for the enum.
 
-=head2 package
+=item package
 
  $ffi->load_custom_type('::Enum', $name, { package => $package }, ... );
 
@@ -124,14 +178,14 @@ This option specifies the Perl package where constants will be defined.
 If not specified, then not constants will be generated.  As per the usual
 convention, the constants will be the upper case of the value names.
 
-=head2 prefix
+=item prefix
 
  $ffi->load_custom_type('::Enum', $name, { prefix => $prefix }, ... );
 
 This specifies an optional prefix to give each constant.  If not specified,
 then no prefix will be used.
 
-=head2 rev
+=item rev
 
  $ffi->load_custom_type('::Enum', $name, { prefix => 'int' }, ... );
  $ffi->load_custom_type('::Enum', $name, { prefix => 'str' }, ... );
@@ -140,7 +194,7 @@ This specifies what should be returned for C functions that return the
 enumerated type.  For strings, use C<str>, and for integer constants
 use C<int>.
 
-=head2 type
+=item type
 
  $ffi->load_custom_type('::Enum', $name, { type => $type }, ... );
 
@@ -170,6 +224,8 @@ Perl:
    'better',
    [best => 12],
  );
+
+=back
 
 =head1 SEE ALSO
 

--- a/t/ffi_platypus_type_enum.t
+++ b/t/ffi_platypus_type_enum.t
@@ -8,7 +8,7 @@ subtest 'default positive enum' => sub {
   $ffi->load_custom_type('::Enum','enum1',
     'one',
     'two',
-    ['four',4],
+    ['four',4, alias => ['abc','xyz']],
     'five',
   );
 
@@ -20,6 +20,8 @@ subtest 'default positive enum' => sub {
   is(dies { $ffi->cast('enum1', 'enum', 'three') }, match qr/illegal enum value three/);
   is(dies { $ffi->cast('enum1', 'enum', 3) }, match qr/illegal enum value 3/);
   is($ffi->cast('enum1', 'enum', 'four'),4);
+  is($ffi->cast('enum1', 'enum', 'abc'),4);
+  is($ffi->cast('enum1', 'enum', 'xyz'),4);
   is($ffi->cast('enum1', 'enum', 'five'),5);
 
   is($ffi->cast('enum', 'enum1', 0), 'one');
@@ -37,13 +39,13 @@ subtest 'maps' => sub {
   $ffi->load_custom_type('::Enum','enum1', { maps => \@maps },
     'one',
     'two',
-    ['four',4],
+    ['four',4, alias => ['abc','xyz']],
     'five',
     ['repeat', 4],
   );
 
   is(\@maps, [
-    { one => 0,   two => 1,   four => 4,   five => 5,  repeat => 4 },
+    { one => 0,   two => 1,   four => 4,   five => 5,  repeat => 4, abc => 4, xyz => 4 },
     { 0 => 'one', 1 => 'two', 4 => 'four', 5 => 'five' },
     'enum',
   ]);
@@ -141,10 +143,18 @@ subtest 'make constants' => sub {
   $ffi->load_custom_type('::Enum', 'enum1', { package => 'Foo1' },
     'one',
     'two',
+    ['three',3, alias => [ 'xyz', 'abc' ]],
+    ['next',undef, alias => ['foo','bar']],
   );
 
   is(Foo1::ONE(), 0);
   is(Foo1::TWO(), 1);
+  is(Foo1::THREE(), 3);
+  is(Foo1::XYZ(), 3);
+  is(Foo1::ABC(), 3);
+  is(Foo1::NEXT(), 4);
+  is(Foo1::FOO(), 4);
+  is(Foo1::BAR(), 4);
 };
 
 subtest 'make constants with prefix' => sub {
@@ -175,6 +185,11 @@ subtest 'define errors' => sub {
   is(
     dies { $ffi->load_custom_type('::Enum','enum1', 'one','one') },
     match qr/one declared twice/,
+  );
+
+  is(
+    dies { $ffi->load_custom_type('::Enum','enum1', [ 'foo' => undef, bar => 'roger', baz => 1 ]) },
+    match qr/unrecognized options: bar baz/,
   );
 };
 

--- a/t/ffi_platypus_type_enum.t
+++ b/t/ffi_platypus_type_enum.t
@@ -144,7 +144,7 @@ subtest 'make constants' => sub {
     'one',
     'two',
     ['three',3, alias => [ 'xyz', 'abc' ]],
-    ['next',undef, alias => ['foo','bar']],
+    ['next', alias => ['foo','bar']],
   );
 
   is(Foo1::ONE(), 0);


### PR DESCRIPTION
This adds the concept of value options (options on the values not on the type as a whole).  The only option so far is for value alises.  This is useful when you have an enum like:

```c
enum {
  FOO,
  BAR,
  BAZ=FOO,  /* intentionally confusing because the alias is out of order */
} foot_t;
```

```perl
  $ffi->load_custom_type('::Enum', 'foo_t', 
    [ 'foo' => undef, alias => ['baz']], 
    'bar',
  );
```

because it lets you define an alias without mucking with the index order.  I prefer this to #4 because it doesn't rely on load order, which I think could be a source of bugs.

~The only nit here is that to use a type alias when you want the implicit next value you have to explicitly ask for `undef`.~


 * [x] update documentation to mention value options
 * [x] ~update documentation to mention `undef` as "explicit" value means use the implicit value.~ use the count of list elements to determine if the value is there instead.