### PR TITLE
Add support for mixed-case constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,9 @@ Type options:
     ```
 
     This option specifies the Perl package where constants will be defined.
-    If not specified, then not constants will be generated.  As per the usual
-    convention, the constants will be the upper case of the value names.
+    If not specified, then no constants will be generated.  Unless otherwise
+    specified (see 'casing' below), the constants will be the upper case of
+    the value names as per the usual convention.
 
     \[version 0.05\]
 
@@ -255,6 +256,21 @@ Type options:
 
     $ffi->attach( f => [ 'foo_t' ] => 'void' );
     ```
+
+- casing
+
+    \[version 0.06\]
+
+    ```perl
+    $ffi->load_custom_type('::Enum', $name, { casing => 'upper' }, ... );
+    $ffi->load_custom_type('::Enum', $name, { casing => 'keep'  }, ... );
+    ```
+
+    When in constant mode, all constant names are by default generated in
+    uppercase as is conventional.  However, some libraries will on occasion
+    define constant names in mixed case.  For these cases, the `casing` option,
+    added in version 0.06, can be set to `keep` to prevent the names from being
+    modified.  The only other allowed value is `upper`, which is the default.
 
 # SEE ALSO
 

--- a/t/ffi_platypus_type_enum.t
+++ b/t/ffi_platypus_type_enum.t
@@ -204,6 +204,18 @@ subtest 'define errors' => sub {
   );
 };
 
+subtest 'make constants with mixed case' => sub {
+  my $ffi = FFI::Platypus->new( api => 1 );
+
+  $ffi->load_custom_type('::Enum', 'enum1', { package => 'Foo3', casing => 'keep' },
+    'CrAzY',
+    'cOnStAnTs',
+  );
+
+  is(Foo3::CrAzY(), 0);
+  is(Foo3::cOnStAnTs(), 1);
+};
+
 sub dv
 {
   [ isdual $_[0] ? (int($_[0]), "$_[0]") : $_[0] ];


### PR DESCRIPTION
As discussed on #native, this PR implements an option to maintain the casing of mixed-case constants. I went with some placeholder names for the option and its supported values, but these can be modified.

I intentionally did not implement a `lower` variant for simplicity, but it could be implemented for completeness.

I went with a single flag with multiple values rather than individual flags (eg. `uppercase`, `mixedcase`) because that meant I didn't have to handle the case of several of them defined simultaneously, but of course, this can also be changed.